### PR TITLE
[F] Add support for Webpack DevServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
+
+
 ## PHP Manifest from Webpack
 
 _Please note this module depends on webpack 2+._
 
 This webpack plugin will create a PHP file in your `output.path` directory with a PHP class in it having two static
- attributes: `$jsFiles` and `$cssFiles`. These can be accessed by your PHP application to learn about what to include
- when rendering the frontend of the site.
+attributes: `$jsFiles` and `$cssFiles`. These can be accessed by your PHP application to learn about what to include
+when rendering the frontend of the site.
 
 ### Install
 
@@ -40,7 +42,7 @@ module.exports = {
 `output` (default: "assets-manifest")
 
 The name of the manifest file to write. Will be written to webpack's
- `output.path` directory and appended with `.php`.
+`output.path` directory and appended with `.php`.
 
 &nbsp;&nbsp;
 
@@ -49,7 +51,7 @@ The name of the manifest file to write. Will be written to webpack's
 The relative file path to the asset files. Example:
 ```javascript
 const phpManifest = new PhpManifestPlugin({
-    path: assets // Asset path will look like /assets/bundle.js
+  path: assets // Asset path will look like /assets/bundle.js
 });
 ```
 
@@ -71,35 +73,24 @@ If used, this should be passed as part of an environment or config variable.
 pathPrefix should also be used to point to the devServer url. Example:
 ```javascript
 const phpManifest = new PhpManifestPlugin({
-    devServer: process.env.WEBPACK_DEV_SERVER, // This should be an env or config boolean
-    // In this example, path prefix is included conditionally so that the prefix is only used when dev server is running
-    pathPrefix:
-      process.env.WEBPACK_DEV_SERVER ? `http://localhost:${port}` : null
-});
-```
+  devServer: process.env.WEBPACK_DEV_SERVER, // This should be an env or config boolean
+  // In this example, path prefix is included conditionally so that the prefix is only used when dev server is running
+  pathPrefix:
+  process.env.WEBPACK_DEV_SERVER ? `http://localhost:${port}` : null
+  });
+  ```
 
-&nbsp;&nbsp;
+  &nbsp;&nbsp;
 
-`phpClassName` (default: "WebpackBuiltFiles")
+  `phpClassName` (default: "WebpackBuiltFiles")
 
-The PHP class name to use for the class. You can generally ignore this
- unless you have a conflicting PHP class named `\WebpackBuiltFiles` in your PHP environment.
+  The PHP class name to use for the class. You can generally ignore this
+  unless you have a conflicting PHP class named `\WebpackBuiltFiles` in your PHP environment.
 
-&nbsp;&nbsp;
+  ## Consuming the manifest
 
-`webpackBuild` (default: false)
+  Currently there's only one implementation for consuming the generated manifest in a PHP application:
 
-By default, webpack-php-manifest writes a manifest file to the webpack output
-location using [node fs](https://nodejs.org/api/fs.html), and not the webpack plugin architecture.
-This ensures that the manifest is built to the same directory even when devServer is used.
-Set this flag to true if, for some reason, you need the php manifest file to be
-built as part of the webpack asset chunk output, or have it built on the devServer.
+  #### October CMS
 
-
-## Consuming the manifest
-
-Currently there's only one implementation for consuming the generated manifest in a PHP application:
-
-#### October CMS
-
-Use the October CMS plugin called [webpackassets-plugin](https://packagist.org/packages/castiron/webpackassets-plugin).
+  Use the October CMS plugin called [webpackassets-plugin](https://packagist.org/packages/castiron/webpackassets-plugin).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This webpack plugin will create a PHP file in your `output.path` directory with 
 attributes: `$jsFiles` and `$cssFiles`. These can be accessed by your PHP application to learn about what to include
 when rendering the frontend of the site.
 
+Note that the php manifest is created with (node fs)[https://nodejs.org/api/fs.html] independently of the Webpack
+output cycle. It will therefor be created in the same location when running a standard Webpack build *or* Webpack Dev Server
+
 ### Install
 
 With Yarn:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _Please note this module depends on webpack 2+._
 This webpack plugin will create a PHP file in your `output.path` directory with a PHP class in it having two static
  attributes: `$jsFiles` and `$cssFiles`. These can be accessed by your PHP application to learn about what to include
  when rendering the frontend of the site.
- 
+
 ### Install
 
 With Yarn:
@@ -19,7 +19,7 @@ With NPM:
 ```
 npm i webpack-php-manifest
 ```
- 
+
 ### Usage
 ```javascript
 // ...in your webpack config file
@@ -41,14 +41,61 @@ module.exports = {
 
 The name of the manifest file to write. Will be written to webpack's
  `output.path` directory and appended with `.php`.
- 
----
 
-`phpClassName` (default: "WebpackBuiltFiles") 
+&nbsp;&nbsp;
+
+`path` (default: "")
+
+The relative file path to the asset files. Example:
+```javascript
+const phpManifest = new PhpManifestPlugin({
+    path: assets // Asset path will look like /assets/bundle.js
+});
+```
+
+&nbsp;&nbsp;
+
+`pathPrefix` (default: "")
+
+An optional absolute URL, that is prepended the asset file paths in php.
+Primarily used with the `devServer` option below.
+
+&nbsp;&nbsp;
+
+`devServer` (default: false)
+
+A flag that tells the plugin if webpack-dev-server is running, and adds
+`webpack-dev-server.js` to the list of JS assets in the file list.
+
+If used, this should be passed as part of an environment or config variable.
+pathPrefix should also be used to point to the devServer url. Example:
+```javascript
+const phpManifest = new PhpManifestPlugin({
+    devServer: process.env.WEBPACK_DEV_SERVER, // This should be an env or config boolean
+    // In this example, path prefix is included conditionally so that the prefix is only used when dev server is running
+    pathPrefix:
+      process.env.WEBPACK_DEV_SERVER ? `http://localhost:${port}` : null
+});
+```
+
+&nbsp;&nbsp;
+
+`phpClassName` (default: "WebpackBuiltFiles")
 
 The PHP class name to use for the class. You can generally ignore this
  unless you have a conflicting PHP class named `\WebpackBuiltFiles` in your PHP environment.
- 
+
+&nbsp;&nbsp;
+
+`webpackBuild` (default: false)
+
+By default, webpack-php-manifest writes a manifest file to the webpack output
+location using [node fs](https://nodejs.org/api/fs.html), and not the webpack plugin architecture.
+This ensures that the manifest is built to the same directory even when devServer is used.
+Set this flag to true if, for some reason, you need the php manifest file to be
+built as part of the webpack asset chunk output, or have it built on the devServer.
+
+
 ## Consuming the manifest
 
 Currently there's only one implementation for consuming the generated manifest in a PHP application:

--- a/index.js
+++ b/index.js
@@ -103,22 +103,10 @@ PhpManifestPlugin.prototype.apply = function apply (compiler) {
       cssFiles: getCssFiles(toInclude, filepath)
     });
 
-    // Insert this list into the webpack build as a new file asset:
-    if (webpackBuild) {
-      compilation.assets[output] = {
-        source: function() {
-          return out;
-        },
-        size: function() {
-          return out.length;
-        }
-      };
-    } else {
-      // Write file using fs
-      // Build directory if it doesn't exist
-      mkOutputDir(path.resolve(compiler.options.output.path));
-      fs.writeFileSync(path.join(compiler.options.output.path, output), out);
-    }
+    // Write file using fs
+    // Build directory if it doesn't exist
+    mkOutputDir(path.resolve(compiler.options.output.path));
+    fs.writeFileSync(path.join(compiler.options.output.path, output), out);
 
     callback();
   });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 var _ = require('lodash')
+var path = require('path')
+var url = require('url')
+var fs = require('fs')
 
 function PhpManifestPlugin (options) {
   this.options = options || {}
@@ -8,20 +11,41 @@ const optionOrFallback = (optionValue, fallbackValue) => optionValue !== undefin
 
 PhpManifestPlugin.prototype.apply = function apply (compiler) {
   var options = this.options;
+  // Get webpack options
+  var filepath = options.path ? options.path : '';
+  // Public path (like www), used when writing the file
+  var prefix = options.pathPrefix ? options.pathPrefix : '';
+  // By default, build the file with node fs. Can be included in webpack with an option.
+  var webpackBuild = options.webpackBuild ? options.webpackBuild : false;
   var output = optionOrFallback(options.output, 'assets-manifest') + '.php';
 
   var phpClassName = optionOrFallback(options.phpClassName, 'WebpackBuiltFiles');
 
-  var getCssFiles = function(filelist) {
-    return _.filter(filelist, function (filename) {
+  var getCssFiles = function(filelist, filepath) {
+    return _.map(_.filter(filelist, function (filename) {
       return filename.endsWith('.css');
+    }), function(filename) {
+      if (!prefix) return path.join(filepath, filename);
+
+      // Return url prefixed path if url exists
+      return url.resolve(prefix, path.join(filepath, filename));
     });
   };
 
-  var getJsFiles = function(filelist) {
-    return _.filter(filelist, function (filename) {
+  var getJsFiles = function(filelist, filepath) {
+    const files = _.map(_.filter(filelist, function (filename) {
       return filename.endsWith('.js');
+    }), function(filename) {
+      if (!prefix) return path.join(filepath, filename);
+
+      // Return url prefixed path if url exists
+      return url.resolve(prefix, path.join(filepath, filename));
     });
+
+    // Add webpack-dev-server js url
+    if (options.devServer) files.push(url.resolve(prefix, 'webpack-dev-server.js'));
+
+    return files;
   };
 
   var arrayToPhpStatic = function(list, varname) {
@@ -51,6 +75,19 @@ PhpManifestPlugin.prototype.apply = function apply (compiler) {
     return out;
   };
 
+  var mkOutputDir = function(dir) {
+    // Make webpack output directory if it doesn't already exist
+    try {
+      fs.mkdirSync(dir);
+    } catch (err) {
+      // If it does exist, don't worry unless there's another error
+      if (err.code !== 'EEXIST') throw err;
+    }
+  }
+
+  // Get output path from webpack
+  var buildPath = compiler.options.output.path;
+
   compiler.plugin('emit', function(compilation, callback) {
 
     var stats = compilation.getStats().toJson();
@@ -62,19 +99,26 @@ PhpManifestPlugin.prototype.apply = function apply (compiler) {
     }
 
     var out = objectToPhpClass(phpClassName, {
-      jsFiles: getJsFiles(toInclude),
-      cssFiles: getCssFiles(toInclude)
+      jsFiles: getJsFiles(toInclude, filepath),
+      cssFiles: getCssFiles(toInclude, filepath)
     });
 
     // Insert this list into the webpack build as a new file asset:
-    compilation.assets[output] = {
-      source: function() {
-        return out;
-      },
-      size: function() {
-        return out.length;
-      }
-    };
+    if (webpackBuild) {
+      compilation.assets[output] = {
+        source: function() {
+          return out;
+        },
+        size: function() {
+          return out.length;
+        }
+      };
+    } else {
+      // Write file using fs
+      // Build directory if it doesn't exist
+      mkOutputDir(path.resolve(compiler.options.output.path));
+      fs.writeFileSync(path.join(compiler.options.output.path, output), out);
+    }
 
     callback();
   });


### PR DESCRIPTION
Add interpolated path function and options that can prepend file urls with a Webpack Dev Server url.
Also change the default way the php manifest is output from being part of the Webpack chunk output cycle to node fs. This ensures that the php manifest is written even if the asset files themselves (css/js) are on the webpack dev server.
Also add option that ensures `webpack-dev-server.js` (often required for hot reloading) is added to the asset list.